### PR TITLE
Add scheduled RDK dependency bump via shared workflow

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -1,0 +1,14 @@
+name: Bump Versions
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: '30 17 * * WED' # 12:30 EST on Wednesdays
+  workflow_dispatch:
+
+jobs:
+  bump-versions:
+    uses: viam-modules/common-workflows/.github/workflows/bump_go_dependencies.yaml@main


### PR DESCRIPTION
Adds a weekly (Wednesday 12:30 EST, plus manual `workflow_dispatch`) job that bumps `go.viam.com/rdk` and `go.viam.com/api` — and only those plus their required transitive minimums, not all dependencies — then opens a PR if anything changed.

This repo had no dependency-update automation; this adds the same weekly RDK bump that `uln2003`, `robotiq`, `rplidar`, and `viam-cartographer` already run, via the new shared workflow.

⚠️ **Depends on viam-modules/common-workflows#23** — that PR adds the reusable workflow this references at `@main`. Merge it first, or the next scheduled run here will fail with workflow-not-found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)